### PR TITLE
Add missing Campfire and Smoking recipes for all foods.

### DIFF
--- a/src/main/resources/data/gofish/recipes/baked_carrot_carp_from_campfire_cooking.json
+++ b/src/main/resources/data/gofish/recipes/baked_carrot_carp_from_campfire_cooking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:campfire_cooking",
+  "ingredient": {
+    "item": "gofish:carrot_carp"
+  },
+  "result": "gofish:baked_carrot_carp",
+  "experience": 0.7,
+  "cookingtime": 600
+}

--- a/src/main/resources/data/gofish/recipes/baked_carrot_carp_from_smoking.json
+++ b/src/main/resources/data/gofish/recipes/baked_carrot_carp_from_smoking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:smoking",
+  "ingredient": {
+    "item": "gofish:carrot_carp"
+  },
+  "result": "gofish:baked_carrot_carp",
+  "experience": 0.7,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/gofish/recipes/baked_endfish_from_campfire_cooking.json
+++ b/src/main/resources/data/gofish/recipes/baked_endfish_from_campfire_cooking.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:smelting",
+  "type": "minecraft:campfire_cooking",
   "ingredient": {
     "item": "gofish:endfish"
   },

--- a/src/main/resources/data/gofish/recipes/baked_endfish_from_campfire_cooking.json
+++ b/src/main/resources/data/gofish/recipes/baked_endfish_from_campfire_cooking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "gofish:endfish"
+  },
+  "result": "gofish:baked_endfish",
+  "experience": 0.7,
+  "cookingtime": 600
+}

--- a/src/main/resources/data/gofish/recipes/baked_endfish_from_smoking.json
+++ b/src/main/resources/data/gofish/recipes/baked_endfish_from_smoking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:smoking",
+  "ingredient": {
+    "item": "gofish:endfish"
+  },
+  "result": "gofish:baked_endfish",
+  "experience": 0.7,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/gofish/recipes/baked_seaweed_from_campfire_cooking.json
+++ b/src/main/resources/data/gofish/recipes/baked_seaweed_from_campfire_cooking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:campfire_cooking",
+  "ingredient": {
+    "item": "gofish:seaweed"
+  },
+  "result": "gofish:baked_seaweed",
+  "experience": 0.25,
+  "cookingtime": 300
+}

--- a/src/main/resources/data/gofish/recipes/baked_seaweed_from_smoking.json
+++ b/src/main/resources/data/gofish/recipes/baked_seaweed_from_smoking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:smoking",
+  "ingredient": {
+    "item": "gofish:seaweed"
+  },
+  "result": "gofish:baked_seaweed",
+  "experience": 0.25,
+  "cookingtime": 50
+}

--- a/src/main/resources/data/gofish/recipes/grilled_blackstone_trout_from_campfire_cooking.json
+++ b/src/main/resources/data/gofish/recipes/grilled_blackstone_trout_from_campfire_cooking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:campfire_cooking",
+  "ingredient": {
+    "item": "gofish:blackstone_trout"
+  },
+  "result": "gofish:grilled_blackstone_trout",
+  "experience": 1.25,
+  "cookingtime": 1200
+}

--- a/src/main/resources/data/gofish/recipes/grilled_blackstone_trout_from_smoking.json
+++ b/src/main/resources/data/gofish/recipes/grilled_blackstone_trout_from_smoking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:smoking",
+  "ingredient": {
+    "item": "gofish:blackstone_trout"
+  },
+  "result": "gofish:grilled_blackstone_trout",
+  "experience": 1.25,
+  "cookingtime": 200
+}


### PR DESCRIPTION
Had to make some decisions to cope with deviations your recipes make from the norm.
* Baked Seaweed recipes all are half typical cooking time (2.5 seconds in a smoker instead of 5, 15 seconds in a campfire instead of 30)
* Grilled Blackstone Trout recipes got the same translations in the opposite direction, as in they take twice the time typical recipes do.  

I'm not sold on my decisions here but it's better the recipes be there rather than be perfect.
Maybe in the future you could consider changing these, like adding a Blackstone Trout blasting recipe, or all Baked Seaweed recipes taking the same amount of time, but giving variable amounts of XP. Your call.